### PR TITLE
bandwidth based quality selection

### DIFF
--- a/src/ui/State.tsx
+++ b/src/ui/State.tsx
@@ -456,7 +456,7 @@ export class StateStore
       this.props.player.tracks.sort(
         (a, b) => Number(b.height) - Number(a.height),
       ),
-      'height',
+      'bandwidth',
     );
 
     let activeTrack = null;

--- a/src/ui/components/Settings.tsx
+++ b/src/ui/components/Settings.tsx
@@ -15,7 +15,10 @@ tabs[SettingsTabs.OPTIONS] = (props: SettingsProps) => (
             item: SettingsTabs.TRACKS,
             label: props.data.getTranslation('Quality'),
             info: `${
-              props.data.activeTrack ? props.data.activeTrack.width : ''
+              props.data.activeTrack ?
+              (props.data.activeTrack.width ?
+                  (""+props.data.activeTrack.width+"x"+props.data.activeTrack.height+", "):"")
+              +(props.data.activeTrack.bandwidth/1e6).toPrecision(2)+"M" : ''
             }`,
           },
           props.data.visibleSettingsTabs.includes(SettingsTabs.SUBTITLES) && {
@@ -55,7 +58,8 @@ tabs[SettingsTabs.TRACKS] = (props: SettingsProps) => (
       items={[
         ...props.data.tracks.map(track => ({
           item: track,
-          label: `${track.width}`,
+          label: `${(track.width?(""+track.width+"x"+track.height+", "):"")
+                     +(track.bandwidth/1e6).toPrecision(2)+"M"}`,
         })),
         {
           item: 'auto',

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -108,6 +108,7 @@ export const translations = {
     'Automatic quality': 'Automática',
     'Enable subtitles': 'Habilitar legenda',
     'Disable subtitles': 'Desabilitar legenda',
+  }
 };
 
 export const getTranslation = languageCode => text => {


### PR DESCRIPTION
standard compliant HLS master playlists may only use the bandwidth field in the description of stream variants, because that's the only required entry, all other fields (e.g. image size) are optional (see: https://developer.apple.com/documentation/http_live_streaming/example_playlists_for_http_live_streaming/creating_a_master_playlist).

the quality selection should therefore mainly based on this this particular entry to work reliable.

this PR also replaces the reported options from the slightly irritating `image width` display to more informative `image width x height bandwidth` entries. this could look overly verbose to some users, but very useful to others...

Fixes: #58